### PR TITLE
fix: Handle closing of session better (follow-up on #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ Inspired by ![git-timemachine](https://github.com/emacsmirror/git-timemachine) w
 Like with any other
 
 ```lua
-{ 'fredeeb/tardis.nvim', config = true }
+{
+    'fredeeb/tardis.nvim',
+    dependencies = { 'nvim-lua/plenary.nvim' },
+    config = true,
+}
 ```
 
-The default options are 
+The default options are
 
 ```lua
 require('tardis-nvim').setup {

--- a/lua/tardis-nvim/init.lua
+++ b/lua/tardis-nvim/init.lua
@@ -29,9 +29,11 @@ local function get_git_root()
 end
 
 local function file_at_rev(revision, path)
+    local relative = string.sub(path, string.len(get_git_root()) + 2, string.len(path))
+
     return Job:new {
         command = 'git',
-        args = { 'show', string.format('%s:%s', revision, path)}
+        args = { 'show', string.format('%s:%s', revision, relative)}
     }:sync()
 end
 

--- a/lua/tardis-nvim/init.lua
+++ b/lua/tardis-nvim/init.lua
@@ -131,10 +131,14 @@ local function tardis()
 
     local path = vim.fn.expand('%:p')
     local filetype = vim.bo.filetype
-
-    local log = get_git_commits_for_current_file(path)
-
+    local log = get_git_commits_for_current_file(path, git_root[1])
     local buffers = {}
+
+    if vim.tbl_isempty(log) then
+        vim.notify('No previous revisions of this file were found', vim.log.levels.WARN)
+        return
+    end
+
     for i, commit in ipairs(log) do
         buffers[i] = {
             fd = vim.api.nvim_create_buf(false, true),

--- a/lua/tardis-nvim/init.lua
+++ b/lua/tardis-nvim/init.lua
@@ -18,9 +18,6 @@ local function get_git_root()
     return Job:new({
         command = 'git',
         args = { 'rev-parse', '--show-toplevel' },
-        on_stderr = function ()
-            vim.notify('Unable to determine git root', vim.log.levels.WARN)
-        end,
     }):sync()
 end
 
@@ -125,7 +122,8 @@ end
 local function tardis()
     local git_root = get_git_root()
 
-    if vim.tbl_isempty(git_root) then
+    if not git_root() then
+        vim.notify('Unable to determine git root', vim.log.levels.WARN)
         return
     end
 

--- a/lua/tardis-nvim/init.lua
+++ b/lua/tardis-nvim/init.lua
@@ -125,7 +125,7 @@ local function setup_autocmds(origin, buffers)
 end
 
 local function tardis()
-    local path = vim.fn.expand('%')
+    local path = vim.fn.expand('%:p')
     local filetype = vim.bo.filetype
 
     local log = get_git_commits_for_current_file(path)


### PR DESCRIPTION
This solution dumbs down the logic for figuring out what buffers are tardis buffers, by just using the initial list of created buffers to also close them, as the initial list is essentially constant and only modified when closing all of the buffers anyways.

In #3 some discussion arose around how to properly end the session. I propose this solution

1. merge the initial 5 commits of #3 
2. merge this which addresse
3. create a new PR for the commits that @Nimjii has added on #3 as a separate PR

