### PR TITLE
change: add buffer id back to buffer names

### DIFF
--- a/lua/tardis-nvim/git.lua
+++ b/lua/tardis-nvim/git.lua
@@ -38,7 +38,7 @@ function M.get_commit_message(commit, root, keymap)
         vim.api.nvim_buf_set_lines(buffer, 0, -1, false, message)
         vim.api.nvim_buf_set_option(buffer, 'filetype', 'gitcommit')
         vim.api.nvim_buf_set_option(buffer, 'readonly', true)
-        vim.api.nvim_buf_set_name(buffer, util.build_commit_buffer_name(commit))
+        vim.api.nvim_buf_set_name(buffer, util.build_commit_buffer_name(commit, buffer))
 
         local current_ui = vim.api.nvim_list_uis()[1]
         if not current_ui then

--- a/lua/tardis-nvim/init.lua
+++ b/lua/tardis-nvim/init.lua
@@ -36,7 +36,7 @@ local function tardis()
     for _, commit in ipairs(log) do
         local buffer = vim.api.nvim_create_buf(false, true)
         local file_at_commit = git.get_file_at_rev(commit, path, git_root)
-        local name = util.build_buffer_name(filename, commit)
+        local name = util.build_buffer_name(filename, commit, buffer)
 
         table.insert(buffers, {
             fd = buffer,

--- a/lua/tardis-nvim/util.lua
+++ b/lua/tardis-nvim/util.lua
@@ -9,12 +9,12 @@ function M.force_delete_buffer(buffer)
     return function() vim.api.nvim_buf_delete(buffer, { force = true }) end
 end
 
-function M.build_commit_buffer_name(commit)
-    return string.format('%s: #%s', constants.name_prefix, commit)
+function M.build_commit_buffer_name(commit, buffer)
+    return string.format('%s: #%s (%s)', constants.name_prefix, commit, buffer)
 end
 
-function M.build_buffer_name(filename, commit)
-    return string.format('%s: %s #%s', constants.name_prefix, filename, commit)
+function M.build_buffer_name(filename, commit, buffer)
+    return string.format('%s: %s #%s (%s)', constants.name_prefix, filename, commit, buffer)
 end
 
 function M.close_session(origin, buffer)


### PR DESCRIPTION
Hey, I saw that you restructured the repository (nice work, btw).
I did notice that you dropped the unique buffer names tho, and wanted to start a little discussion.

I implemented that change so it's possible to open multiple tardis sessions on the same file (the rename will fail if the name isn't unique).
For the git buffers, the unique name isn't as important, but it still helps if you jump out of the git buffer and press m again (this will just open a new git buffer without causing problems, although the old one will still be open as well).

Now the better solution for the normal buffers would be to just use the existing buffers if there is already an existing tardis session for this file (I wasn't sure how to do that tho, and you also can't close them on exit if another tardis session is still using them, so I'm guessing that this would require a global state).

And the better solution for the git buffer would be to jump back into the existing one (if one exists) but I wasn't really sure how to do that either.

If you have an idea on how to implement one of the better solutions, feel free to close this PR; otherwise, feel free to merge it.