### PR TITLE
Fix notification message on going past latest revision

### DIFF
--- a/lua/tardis-nvim/session.lua
+++ b/lua/tardis-nvim/session.lua
@@ -132,7 +132,7 @@ end
 
 function M.Session:prev_buffer()
     if not self:goto_buffer(self.curret_buffer_index - 1) then
-        vim.notify('No earlier revisions of file')
+        vim.notify('No later revisions of file')
     end
 end
 


### PR DESCRIPTION
Thanks for the great plugin. I missed the same thing coming from Emacs.

When navigating past the earliest revision of the file, the notification says "No earlier revisions of file". But the message is the exactly same when going past the **latest** revision. This confused me a little, so I changed it to "No later revisions of the file". Hope the change makes sense?